### PR TITLE
Fix missing PostGIS dialect

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -47,16 +47,20 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.hibernate.orm</groupId>
+                        <artifactId>hibernate-spatial</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <optional>true</optional>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
## Summary
- add Hibernate Spatial library to the backend

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6887623c507c832c8b0fa3257848011c