### PR TITLE
Align API endpoints and status values

### DIFF
--- a/Front-End/src/app/admin/parcels/page.tsx
+++ b/Front-End/src/app/admin/parcels/page.tsx
@@ -59,7 +59,7 @@ interface ParcelForm {
   vertices: { lambertX: string; lambertY: string }[]
 }
 
-const statuses = ['AVAILABLE', 'RESERVED', 'OCCUPIED', 'SHOWROOM']
+const statuses = ['LIBRE', 'RESERVEE', 'INDISPONIBLE', 'VENDU', 'EN_DEVELOPPEMENT']
 
 export default function ParcelsAdmin() {
   const router = useRouter()
@@ -73,7 +73,7 @@ export default function ParcelsAdmin() {
     reference: '',
     area: '',
     price: '',
-    status: 'AVAILABLE',
+    status: 'LIBRE',
     isFree: true,
     isShowroom: false,
     cos: '',
@@ -206,7 +206,7 @@ export default function ParcelsAdmin() {
       reference: '',
       area: '',
       price: '',
-      status: 'AVAILABLE',
+      status: 'LIBRE',
       isFree: true,
       isShowroom: false,
       cos: '',
@@ -258,7 +258,7 @@ export default function ParcelsAdmin() {
       reference: '',
       area: '',
       price: '',
-      status: 'AVAILABLE',
+      status: 'LIBRE',
       isFree: true,
       isShowroom: false,
       cos: '',

--- a/Front-End/src/app/admin/zones/page.tsx
+++ b/Front-End/src/app/admin/zones/page.tsx
@@ -62,10 +62,11 @@ interface ZoneForm {
 }
 
 const statuses = [
-  'AVAILABLE',
-  'RESERVED',
-  'OCCUPIED',
-  'SHOWROOM',
+  'LIBRE',
+  'RESERVEE',
+  'INDISPONIBLE',
+  'VENDU',
+  'EN_DEVELOPPEMENT',
 ]
 
 export default function ZonesAdmin() {
@@ -85,7 +86,7 @@ export default function ZonesAdmin() {
     address: '',
     totalArea: '',
     price: '',
-    status: 'AVAILABLE',
+    status: 'LIBRE',
 
     lambertX: '',
     lambertY: '',
@@ -241,7 +242,7 @@ export default function ZonesAdmin() {
       address: '',
       totalArea: '',
       price: '',
-      status: 'AVAILABLE',
+      status: 'LIBRE',
       lambertX: '',
       lambertY: '',
       latitude: '',
@@ -296,7 +297,7 @@ export default function ZonesAdmin() {
       address: '',
       totalArea: '',
       price: '',
-      status: 'AVAILABLE',
+      status: 'LIBRE',
       lambertX: '',
       lambertY: '',
       latitude: '',

--- a/Front-End/src/components/SearchBar.tsx
+++ b/Front-End/src/components/SearchBar.tsx
@@ -33,7 +33,7 @@ export default function SearchBar({ onSearch }: { onSearch?: (f: Filters) => voi
 
   const [regions, setRegions] = useState<{ id: string; name: string }[]>([])
   const [zoneTypes, setZoneTypes] = useState<{ id: string; name: string }[]>([])
-  const statuses = ['AVAILABLE', 'RESERVED', 'OCCUPIED', 'SHOWROOM']
+  const statuses = ['LIBRE', 'RESERVEE', 'INDISPONIBLE', 'VENDU', 'EN_DEVELOPPEMENT']
   const priceRanges = [
     { label: 'Tout prix', min: undefined, max: undefined },
     { label: 'Moins de 500 DH/m²', min: undefined, max: 500 },

--- a/Front-End/src/components/ZoneGrid.tsx
+++ b/Front-End/src/components/ZoneGrid.tsx
@@ -42,14 +42,16 @@ export default function ZoneGrid() {
 
   const mapStatus = (status: string): IndustrialZone['status'] => {
     switch (status) {
-      case 'RESERVED':
-        return 'Réservé';
-      case 'OCCUPIED':
-        return 'Occupé';
-      case 'SHOWROOM':
-        return 'Showroom';
+      case 'RESERVEE':
+        return 'Réservée';
+      case 'INDISPONIBLE':
+        return 'Indisponible';
+      case 'VENDU':
+        return 'Vendu';
+      case 'EN_DEVELOPPEMENT':
+        return 'En développement';
       default:
-        return 'Disponible';
+        return 'Libre';
     }
   };
 

--- a/Front-End/src/components/ZoneMap.tsx
+++ b/Front-End/src/components/ZoneMap.tsx
@@ -139,22 +139,25 @@ export default function ZoneMap({ zone }: { zone: Zone }) {
         })();
 
   const zoneColor: Record<string, string> = {
-    AVAILABLE: "green",
-    RESERVED: "orange",
-    OCCUPIED: "red",
-    SHOWROOM: "blue",
+    LIBRE: "green",
+    RESERVEE: "orange",
+    INDISPONIBLE: "red",
+    VENDU: "blue",
+    EN_DEVELOPPEMENT: "gray",
   };
 
   const parcelColor = (s: string) => {
     switch (s) {
-      case "AVAILABLE":
+      case "LIBRE":
         return "green";
-      case "RESERVED":
+      case "RESERVEE":
         return "red";
-      case "OCCUPIED":
+      case "INDISPONIBLE":
         return "gray";
-      case "SHOWROOM":
+      case "VENDU":
         return "blue";
+      case "EN_DEVELOPPEMENT":
+        return "orange";
       default:
         return "gray";
     }
@@ -206,7 +209,7 @@ export default function ZoneMap({ zone }: { zone: Zone }) {
                         Lat: {p.latitude.toFixed(5)}, Lon: {p.longitude.toFixed(5)}
                       </div>
                     )}
-                    {p.status === "AVAILABLE" && p.isFree && (
+                    {p.status === "LIBRE" && p.isFree && (
                       <Button
                         size="sm"
                         className="mt-1"

--- a/backend/src/main/java/com/industria/platform/controller/ActivityController.java
+++ b/backend/src/main/java/com/industria/platform/controller/ActivityController.java
@@ -1,0 +1,49 @@
+package com.industria.platform.controller;
+
+import com.industria.platform.dto.ActivityDto;
+import com.industria.platform.entity.Activity;
+import com.industria.platform.repository.ActivityRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/activities")
+public class ActivityController {
+    private final ActivityRepository repo;
+    public ActivityController(ActivityRepository repo) {this.repo = repo;}
+
+    @GetMapping
+    public List<ActivityDto> all() {
+        return repo.findAll().stream().map(this::toDto).toList();
+    }
+
+    @PostMapping
+    public ActivityDto create(@RequestBody ActivityDto dto) {
+        Activity a = new Activity();
+        updateEntity(a, dto);
+        repo.save(a);
+        return toDto(a);
+    }
+
+    @PutMapping("/{id}")
+    public ActivityDto update(@PathVariable String id, @RequestBody ActivityDto dto) {
+        Activity a = repo.findById(id).orElseThrow();
+        updateEntity(a, dto);
+        repo.save(a);
+        return toDto(a);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable String id) { repo.deleteById(id); }
+
+    private void updateEntity(Activity a, ActivityDto dto) {
+        a.setName(dto.name());
+        a.setDescription(dto.description());
+        a.setIcon(dto.icon());
+    }
+
+    private ActivityDto toDto(Activity a) {
+        return new ActivityDto(a.getId(), a.getName(), a.getDescription(), a.getIcon());
+    }
+}

--- a/backend/src/main/java/com/industria/platform/controller/AdminStatsController.java
+++ b/backend/src/main/java/com/industria/platform/controller/AdminStatsController.java
@@ -1,0 +1,32 @@
+package com.industria.platform.controller;
+
+import com.industria.platform.dto.AdminStatsDto;
+import com.industria.platform.repository.AppointmentRepository;
+import com.industria.platform.repository.ParcelRepository;
+import com.industria.platform.repository.UserRepository;
+import com.industria.platform.repository.ZoneRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminStatsController {
+    private final ZoneRepository zoneRepo;
+    private final ParcelRepository parcelRepo;
+    private final AppointmentRepository apptRepo;
+    private final UserRepository userRepo;
+
+    public AdminStatsController(ZoneRepository zoneRepo, ParcelRepository parcelRepo,
+                                AppointmentRepository apptRepo, UserRepository userRepo) {
+        this.zoneRepo = zoneRepo;
+        this.parcelRepo = parcelRepo;
+        this.apptRepo = apptRepo;
+        this.userRepo = userRepo;
+    }
+
+    @GetMapping("/stats")
+    public AdminStatsDto stats() {
+        return new AdminStatsDto(zoneRepo.count(), parcelRepo.count(), apptRepo.count(), userRepo.count());
+    }
+}

--- a/backend/src/main/java/com/industria/platform/controller/AmenityController.java
+++ b/backend/src/main/java/com/industria/platform/controller/AmenityController.java
@@ -1,0 +1,47 @@
+package com.industria.platform.controller;
+
+import com.industria.platform.dto.AmenityDto;
+import com.industria.platform.entity.Amenity;
+import com.industria.platform.repository.AmenityRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/amenities")
+public class AmenityController {
+    private final AmenityRepository repo;
+    public AmenityController(AmenityRepository repo) {this.repo = repo;}
+
+    @GetMapping
+    public List<AmenityDto> all() { return repo.findAll().stream().map(this::toDto).toList(); }
+
+    @PostMapping
+    public AmenityDto create(@RequestBody AmenityDto dto) {
+        Amenity a = new Amenity();
+        updateEntity(a, dto);
+        repo.save(a);
+        return toDto(a);
+    }
+
+    @PutMapping("/{id}")
+    public AmenityDto update(@PathVariable String id, @RequestBody AmenityDto dto) {
+        Amenity a = repo.findById(id).orElseThrow();
+        updateEntity(a, dto);
+        repo.save(a);
+        return toDto(a);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable String id) { repo.deleteById(id); }
+
+    private void updateEntity(Amenity a, AmenityDto dto) {
+        a.setName(dto.name());
+        a.setDescription(dto.description());
+        a.setIcon(dto.icon());
+    }
+
+    private AmenityDto toDto(Amenity a) {
+        return new AmenityDto(a.getId(), a.getName(), a.getDescription(), a.getIcon());
+    }
+}

--- a/backend/src/main/java/com/industria/platform/controller/AppointmentAdminController.java
+++ b/backend/src/main/java/com/industria/platform/controller/AppointmentAdminController.java
@@ -1,0 +1,52 @@
+package com.industria.platform.controller;
+
+import com.industria.platform.entity.Appointment;
+import com.industria.platform.repository.AppointmentRepository;
+import com.industria.platform.repository.ParcelRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/appointments")
+public class AppointmentAdminController {
+    private final AppointmentRepository repo;
+    private final ParcelRepository parcelRepo;
+
+    public AppointmentAdminController(AppointmentRepository repo, ParcelRepository parcelRepo) {
+        this.repo = repo;
+        this.parcelRepo = parcelRepo;
+    }
+
+    @GetMapping
+    public List<Appointment> all() { return repo.findAll(); }
+
+    @GetMapping("/{id}")
+    public Appointment get(@PathVariable String id) { return repo.findById(id).orElse(null); }
+
+    @PostMapping
+    public Appointment create(@RequestBody Appointment appt) {
+        if (appt.getParcel() != null && appt.getParcel().getId() != null) {
+            appt.setParcel(parcelRepo.findById(appt.getParcel().getId()).orElse(null));
+        }
+        return repo.save(appt);
+    }
+
+    @PutMapping("/{id}")
+    public Appointment update(@PathVariable String id, @RequestBody Appointment appt) {
+        Appointment a = repo.findById(id).orElseThrow();
+        a.setContactName(appt.getContactName());
+        a.setContactEmail(appt.getContactEmail());
+        a.setContactPhone(appt.getContactPhone());
+        a.setCompanyName(appt.getCompanyName());
+        a.setMessage(appt.getMessage());
+        a.setRequestedDate(appt.getRequestedDate());
+        a.setStatus(appt.getStatus());
+        if (appt.getParcel() != null && appt.getParcel().getId() != null)
+            a.setParcel(parcelRepo.findById(appt.getParcel().getId()).orElse(null));
+        return repo.save(a);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable String id) { repo.deleteById(id); }
+}

--- a/backend/src/main/java/com/industria/platform/controller/ParcelController.java
+++ b/backend/src/main/java/com/industria/platform/controller/ParcelController.java
@@ -1,8 +1,12 @@
 package com.industria.platform.controller;
 
+import com.industria.platform.dto.ParcelDto;
 import com.industria.platform.entity.Parcel;
 import com.industria.platform.entity.ParcelStatus;
+import com.industria.platform.repository.ParcelRepository;
+import com.industria.platform.repository.ZoneRepository;
 import com.industria.platform.service.StatusService;
+import java.util.List;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,15 +15,64 @@ import org.springframework.web.bind.annotation.*;
 public class ParcelController {
 
     private final StatusService statusService;
+    private final ParcelRepository repo;
+    private final ZoneRepository zoneRepo;
 
-    public ParcelController(StatusService statusService) {
+    public ParcelController(StatusService statusService, ParcelRepository repo, ZoneRepository zoneRepo) {
         this.statusService = statusService;
+        this.repo = repo;
+        this.zoneRepo = zoneRepo;
     }
 
     @PutMapping("/{id}/status")
     @PreAuthorize("hasRole('ZONE_MANAGER') or hasRole('CONTENT_MANAGER') or hasRole('ADMIN')")
     public Parcel updateStatus(@PathVariable String id, @RequestBody StatusRequest request) {
         return statusService.updateParcelStatus(id, request.status());
+    }
+
+    @GetMapping
+    public List<ParcelDto> all() {
+        return repo.findAll().stream().map(this::toDto).toList();
+    }
+
+    @GetMapping("/{id}")
+    public ParcelDto get(@PathVariable String id) {
+        return repo.findById(id).map(this::toDto).orElse(null);
+    }
+
+    @PostMapping
+    public ParcelDto create(@RequestBody ParcelDto dto) {
+        Parcel p = new Parcel();
+        updateEntity(p, dto);
+        repo.save(p);
+        return toDto(p);
+    }
+
+    @PutMapping("/{id}")
+    public ParcelDto update(@PathVariable String id, @RequestBody ParcelDto dto) {
+        Parcel p = repo.findById(id).orElseThrow();
+        updateEntity(p, dto);
+        repo.save(p);
+        return toDto(p);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable String id) { repo.deleteById(id); }
+
+    private void updateEntity(Parcel p, ParcelDto dto) {
+        p.setReference(dto.reference());
+        p.setArea(dto.area());
+        p.setStatus(dto.status() == null ? null : ParcelStatus.valueOf(dto.status()));
+        p.setIsShowroom(dto.isShowroom());
+        if (dto.zoneId() != null)
+            p.setZone(zoneRepo.findById(dto.zoneId()).orElse(null));
+    }
+
+    private ParcelDto toDto(Parcel p) {
+        return new ParcelDto(p.getId(), p.getReference(), p.getArea(),
+                p.getStatus() == null ? null : p.getStatus().name(),
+                p.getIsShowroom(),
+                p.getZone() == null ? null : p.getZone().getId());
     }
 
     public record StatusRequest(ParcelStatus status) {}

--- a/backend/src/main/java/com/industria/platform/dto/ActivityDto.java
+++ b/backend/src/main/java/com/industria/platform/dto/ActivityDto.java
@@ -1,0 +1,3 @@
+package com.industria.platform.dto;
+
+public record ActivityDto(String id, String name, String description, String icon) {}

--- a/backend/src/main/java/com/industria/platform/dto/AdminStatsDto.java
+++ b/backend/src/main/java/com/industria/platform/dto/AdminStatsDto.java
@@ -1,0 +1,3 @@
+package com.industria.platform.dto;
+
+public record AdminStatsDto(long zones, long parcels, long appointments, long users) {}

--- a/backend/src/main/java/com/industria/platform/dto/AmenityDto.java
+++ b/backend/src/main/java/com/industria/platform/dto/AmenityDto.java
@@ -1,0 +1,3 @@
+package com.industria.platform.dto;
+
+public record AmenityDto(String id, String name, String description, String icon) {}


### PR DESCRIPTION
## Summary
- add activity and amenity CRUD controllers
- expose admin statistics
- extend parcel and zone controllers with CRUD operations
- provide appointment admin controller
- add DTO classes for new endpoints
- harmonise status values in frontend components

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68886bffc66c832cab69a7ad523712f1