### PR TITLE
Reintroduce security matcher

### DIFF
--- a/backend/src/main/java/com/industria/platform/config/SecurityConfig.java
+++ b/backend/src/main/java/com/industria/platform/config/SecurityConfig.java
@@ -29,6 +29,9 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
             .oauth2ResourceServer(oauth2 -> oauth2
+                .securityMatcher(request ->
+                    !HttpMethod.GET.matches(request.getMethod())
+                )
                 .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
             );
         return http.build();


### PR DESCRIPTION
## Summary
- apply JWT auth only for non-GET requests

## Testing
- `mvn test` *(fails: could not download org.springframework.boot:spring-boot-starter-parent from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6888b432e654832cb65f9a0e89bcb5d9