### PR TITLE
Fix greeting controller test path

### DIFF
--- a/backend/src/test/java/com/industria/platform/controller/GreetingControllerTest.java
+++ b/backend/src/test/java/com/industria/platform/controller/GreetingControllerTest.java
@@ -20,7 +20,7 @@ class GreetingControllerTest {
 
     @Test
     void greetingInFrench() throws Exception {
-        mockMvc.perform(get("/public/greeting").header("Accept-Language", "fr"))
+        mockMvc.perform(get("/api/public/greeting").header("Accept-Language", "fr"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("Bienvenue sur la plateforme"));
     }


### PR DESCRIPTION
## Summary
- update greeting controller test path to use `/api/public/greeting`

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888b433a310832cad82555a2af24480