### PR TITLE
Handle zone activity and amenity IDs

### DIFF
--- a/backend/src/main/java/com/industria/platform/controller/ZoneController.java
+++ b/backend/src/main/java/com/industria/platform/controller/ZoneController.java
@@ -3,9 +3,16 @@ package com.industria.platform.controller;
 import com.industria.platform.dto.RegionDto;
 import com.industria.platform.dto.ZoneDto;
 import com.industria.platform.dto.ZoneTypeDto;
+import com.industria.platform.entity.Activity;
+import com.industria.platform.entity.Amenity;
 import com.industria.platform.entity.Zone;
+import com.industria.platform.entity.ZoneActivity;
 import com.industria.platform.entity.ZoneAmenity;
 import com.industria.platform.entity.ZoneStatus;
+import com.industria.platform.repository.ActivityRepository;
+import com.industria.platform.repository.AmenityRepository;
+import com.industria.platform.repository.ZoneActivityRepository;
+import com.industria.platform.repository.ZoneAmenityRepository;
 import com.industria.platform.repository.ZoneRepository;
 import com.industria.platform.service.StatusService;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,10 +25,23 @@ public class ZoneController {
 
     private final StatusService statusService;
     private final ZoneRepository zoneRepository;
+    private final ActivityRepository activityRepository;
+    private final AmenityRepository amenityRepository;
+    private final ZoneActivityRepository zoneActivityRepository;
+    private final ZoneAmenityRepository zoneAmenityRepository;
 
-    public ZoneController(StatusService statusService, ZoneRepository zoneRepository) {
+    public ZoneController(StatusService statusService,
+                          ZoneRepository zoneRepository,
+                          ActivityRepository activityRepository,
+                          AmenityRepository amenityRepository,
+                          ZoneActivityRepository zoneActivityRepository,
+                          ZoneAmenityRepository zoneAmenityRepository) {
         this.statusService = statusService;
         this.zoneRepository = zoneRepository;
+        this.activityRepository = activityRepository;
+        this.amenityRepository = amenityRepository;
+        this.zoneActivityRepository = zoneActivityRepository;
+        this.zoneAmenityRepository = zoneAmenityRepository;
     }
 
     @PutMapping("/{id}/status")
@@ -41,7 +61,9 @@ public class ZoneController {
                 z.getStatus().name(),
                 z.getRegion() == null ? null : new RegionDto(z.getRegion().getId(), z.getRegion().getName(), z.getRegion().getCode(), null),
                 z.getZoneType() == null ? null : new ZoneTypeDto(z.getZoneType().getId(), z.getZoneType().getName()),
-                z.getAmenities() == null ? List.of() : z.getAmenities().stream().map(ZoneAmenity::getAmenity).map(a -> a.getName()).toList()
+                z.getAmenities() == null ? List.of() : z.getAmenities().stream().map(ZoneAmenity::getAmenity).map(a -> a.getName()).toList(),
+                null,
+                null
         )).toList();
     }
 
@@ -52,8 +74,56 @@ public class ZoneController {
                 z.getId(), z.getName(), z.getDescription(), z.getTotalArea(), z.getPrice(), z.getStatus().name(),
                 z.getRegion() == null ? null : new RegionDto(z.getRegion().getId(), z.getRegion().getName(), z.getRegion().getCode(), null),
                 z.getZoneType() == null ? null : new ZoneTypeDto(z.getZoneType().getId(), z.getZoneType().getName()),
-                z.getAmenities() == null ? List.of() : z.getAmenities().stream().map(ZoneAmenity::getAmenity).map(a -> a.getName()).toList()
+                z.getAmenities() == null ? List.of() : z.getAmenities().stream().map(ZoneAmenity::getAmenity).map(a -> a.getName()).toList(),
+                null,
+                null
         );
+    }
+
+    private void updateEntity(Zone z, ZoneDto dto) {
+        z.setName(dto.name());
+        z.setDescription(dto.description());
+        z.setTotalArea(dto.totalArea());
+        z.setPrice(dto.price());
+        if (dto.status() != null) {
+            z.setStatus(ZoneStatus.valueOf(dto.status()));
+        }
+
+        // clear existing relations
+        if (z.getActivities() != null && !z.getActivities().isEmpty()) {
+            zoneActivityRepository.deleteAll(z.getActivities());
+            z.getActivities().clear();
+        }
+        if (z.getAmenities() != null && !z.getAmenities().isEmpty()) {
+            zoneAmenityRepository.deleteAll(z.getAmenities());
+            z.getAmenities().clear();
+        }
+
+        if (dto.activityIds() != null) {
+            for (String aid : dto.activityIds()) {
+                Activity act = activityRepository.findById(aid).orElse(null);
+                if (act != null) {
+                    ZoneActivity za = new ZoneActivity();
+                    za.setZone(z);
+                    za.setActivity(act);
+                    zoneActivityRepository.save(za);
+                    z.getActivities().add(za);
+                }
+            }
+        }
+
+        if (dto.amenityIds() != null) {
+            for (String mid : dto.amenityIds()) {
+                Amenity am = amenityRepository.findById(mid).orElse(null);
+                if (am != null) {
+                    ZoneAmenity zm = new ZoneAmenity();
+                    zm.setZone(z);
+                    zm.setAmenity(am);
+                    zoneAmenityRepository.save(zm);
+                    z.getAmenities().add(zm);
+                }
+            }
+        }
     }
 
     public record StatusRequest(ZoneStatus status) {}

--- a/backend/src/main/java/com/industria/platform/dto/ZoneDto.java
+++ b/backend/src/main/java/com/industria/platform/dto/ZoneDto.java
@@ -2,6 +2,14 @@ package com.industria.platform.dto;
 
 import java.util.List;
 
-public record ZoneDto(String id, String name, String description, Double totalArea,
-                      Double price, String status, RegionDto region,
-                      ZoneTypeDto zoneType, List<String> amenities) {}
+public record ZoneDto(String id,
+                      String name,
+                      String description,
+                      Double totalArea,
+                      Double price,
+                      String status,
+                      RegionDto region,
+                      ZoneTypeDto zoneType,
+                      List<String> amenities,
+                      List<String> activityIds,
+                      List<String> amenityIds) {}


### PR DESCRIPTION
## Summary
- allow ZoneDto to carry arrays of `activityIds` and `amenityIds`
- inject repositories into `ZoneController`
- implement `updateEntity` logic to refresh `ZoneActivity` and `ZoneAmenity` relations

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6888b4350ef0832c8416617b62f3b44f