### PR TITLE
Fix Windows scripts for database and Keycloak setup

### DIFF
--- a/scripts/init_db.bat
+++ b/scripts/init_db.bat
@@ -7,7 +7,9 @@ if "%DB_NAME%"=="" set DB_NAME=industria
 if "%DB_USER%"=="" set DB_USER=postgres
 if "%DB_PASSWORD%"=="" set DB_PASSWORD=postgres
 
-set PSQL=docker compose exec -T %DB_CONTAINER% env PGPASSWORD=%DB_PASSWORD% psql -U %DB_USER% -d %DB_NAME%
+rem Build psql command to run inside the database container
+rem Use -e to pass PGPASSWORD in an OS agnostic way
+set "PSQL=docker compose exec -e PGPASSWORD=%DB_PASSWORD% -T %DB_CONTAINER% psql -U %DB_USER% -d %DB_NAME%"
 
 for /f %%A in ('%PSQL% -tAc "SELECT 1 FROM information_schema.tables WHERE table_name=''users''"') do set HAS_TABLE=%%A
 if "!HAS_TABLE!"=="1" (

--- a/scripts/setup-keycloak-users.bat
+++ b/scripts/setup-keycloak-users.bat
@@ -58,10 +58,7 @@ echo ✅ Keycloak accessible
 
 REM Obtenir le token d'accès admin
 echo 🔐 Authentification admin...
-for /f "usebackq tokens=*" %%i in (`curl -s -X POST "%KEYCLOAK_URL%/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin&password=!KEYCLOAK_ADMIN_PASSWORD!&grant_type=password&client_id=admin-cli" ^| findstr /C:"access_token" ^| for /f "tokens=2 delims=:" %%j in ('more') do @echo %%j ^| for /f "tokens=1 delims=," %%k in ('more') do @echo %%k ^| for /f "tokens=*" %%l in ('more') do @echo %%l`) do set ACCESS_TOKEN=%%i
-
-REM Nettoyer le token (supprimer les guillemets)
-set ACCESS_TOKEN=!ACCESS_TOKEN:"=!
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "(Invoke-RestMethod -Method Post -Uri '%KEYCLOAK_URL%/realms/master/protocol/openid-connect/token' -Body 'username=admin&password=!KEYCLOAK_ADMIN_PASSWORD!&grant_type=password&client_id=admin-cli' -ContentType 'application/x-www-form-urlencoded').access_token"`) do set "ACCESS_TOKEN=%%i"
 
 if "!ACCESS_TOKEN!"=="" (
     echo ❌ Impossible d'obtenir le token d'accès


### PR DESCRIPTION
## Summary
- fix Windows DB initialization script to set PGPASSWORD via `-e`
- simplify Keycloak user setup to fetch token using PowerShell
- ensure newline at end of batch file

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68894d05e5dc832c831aeda1b5720c59