### PR TITLE
feat: add all endpoints and fetch full lists

### DIFF
--- a/Front-End/src/app/admin/activities/page.tsx
+++ b/Front-End/src/app/admin/activities/page.tsx
@@ -21,6 +21,8 @@ interface Activity {
 export default function ActivitiesAdmin() {
   const router = useRouter()
   const [items, setItems] = useState<Activity[]>([])
+  const [allActivities, setAllActivities] = useState<Activity[]>([])
+  const [selectedActivityId, setSelectedActivityId] = useState('')
   const [currentPage, setCurrentPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
   const itemsPerPage = 10
@@ -43,6 +45,12 @@ export default function ActivitiesAdmin() {
   }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { load(currentPage) }, [currentPage])
+
+  useEffect(() => {
+    fetchApi<Activity[]>("/api/activities/all")
+      .then(setAllActivities)
+      .catch(() => setAllActivities([]))
+  }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -127,6 +135,23 @@ export default function ActivitiesAdmin() {
           </table>
         </CardContent>
       </Card>
+
+      <select
+        className="border p-2"
+        value={selectedActivityId}
+        onChange={e => setSelectedActivityId(e.target.value)}
+      >
+        {allActivities.length === 0 ? (
+          <option value="">Aucune activité trouvée</option>
+        ) : (
+          <>
+            <option value="">-- Sélectionnez une activité --</option>
+            {allActivities.map(a => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </>
+        )}
+      </select>
 
       <Pagination
         totalItems={totalPages * itemsPerPage}

--- a/Front-End/src/app/admin/amenities/page.tsx
+++ b/Front-End/src/app/admin/amenities/page.tsx
@@ -22,6 +22,8 @@ interface Amenity {
 export default function AmenitiesAdmin() {
   const router = useRouter()
   const [items, setItems] = useState<Amenity[]>([])
+  const [allAmenities, setAllAmenities] = useState<Amenity[]>([])
+  const [selectedAmenityId, setSelectedAmenityId] = useState('')
   const [currentPage, setCurrentPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
   const itemsPerPage = 10
@@ -45,6 +47,12 @@ export default function AmenitiesAdmin() {
   }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { load(currentPage) }, [currentPage])
+
+  useEffect(() => {
+    fetchApi<Amenity[]>("/api/amenities/all")
+      .then(setAllAmenities)
+      .catch(() => setAllAmenities([]))
+  }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -131,6 +139,23 @@ export default function AmenitiesAdmin() {
           </table>
         </CardContent>
       </Card>
+
+      <select
+        className="border p-2"
+        value={selectedAmenityId}
+        onChange={e => setSelectedAmenityId(e.target.value)}
+      >
+        {allAmenities.length === 0 ? (
+          <option value="">Aucun équipement trouvé</option>
+        ) : (
+          <>
+            <option value="">-- Sélectionnez un équipement --</option>
+            {allAmenities.map(a => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </>
+        )}
+      </select>
 
       <Pagination
         totalItems={totalPages * itemsPerPage}

--- a/Front-End/src/app/admin/appointments/page.tsx
+++ b/Front-End/src/app/admin/appointments/page.tsx
@@ -37,7 +37,7 @@ export default function AppointmentsAdmin() {
   const [currentPage, setCurrentPage] = useState(1)
   const itemsPerPage = 10
   const [open, setOpen] = useState(false)
-  const [parcels, setParcels] = useState<{ id: string; reference: string }[]>([])
+  const [allParcels, setAllParcels] = useState<{ id: string; reference: string }[]>([])
   const [form, setForm] = useState<Appointment>({
     id: '',
     contactName: '',
@@ -52,17 +52,19 @@ export default function AppointmentsAdmin() {
 
 
   async function load() {
-    const [a, p] = await Promise.all([
-      fetchApi<Appointment[]>('/api/appointments'),
-      fetchApi<{ id: string; reference: string }[]>('/api/parcels'),
-    ])
+    const a = await fetchApi<Appointment[]>('/api/appointments')
     if (a) {
       setItems(a)
       setCurrentPage(1)
     }
-    if (p) setParcels(p)
   }
   useEffect(() => { load() }, [])
+
+  useEffect(() => {
+    fetchApi<{ id: string; reference: string }[]>("/api/parcels/all")
+      .then(setAllParcels)
+      .catch(() => setAllParcels([]))
+  }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -233,9 +235,13 @@ export default function AppointmentsAdmin() {
                   <SelectValue placeholder="Choisir" />
                 </SelectTrigger>
                 <SelectContent>
-                  {parcels.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>{p.reference}</SelectItem>
-                  ))}
+                  {allParcels.length === 0 ? (
+                    <SelectItem value="" disabled>Aucune parcelle trouvée</SelectItem>
+                  ) : (
+                    allParcels.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>{p.reference}</SelectItem>
+                    ))
+                  )}
                 </SelectContent>
               </Select>
             </div>

--- a/Front-End/src/app/admin/parcels/page.tsx
+++ b/Front-End/src/app/admin/parcels/page.tsx
@@ -48,11 +48,13 @@ const statuses = ['AVAILABLE', 'RESERVED', 'OCCUPIED', 'SHOWROOM']
 export default function ParcelsAdmin() {
   const router = useRouter()
   const [items, setItems] = useState<Parcel[]>([])
+  const [allParcels, setAllParcels] = useState<Parcel[]>([])
+  const [selectedParcelId, setSelectedParcelId] = useState('')
   const [currentPage, setCurrentPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
   const itemsPerPage = 10
   const [open, setOpen] = useState(false)
-  const [zones, setZones] = useState<{ id: string; name: string }[]>([])
+  const [allZones, setAllZones] = useState<{ id: string; name: string }[]>([])
   const [form, setForm] = useState<ParcelForm>({
     id: '',
     reference: '',
@@ -66,19 +68,29 @@ export default function ParcelsAdmin() {
 
 
   async function load(page = currentPage) {
-    const [p, z] = await Promise.all([
-      fetchApi<ListResponse<Parcel>>(`/api/parcels?page=${page}&limit=${itemsPerPage}`),
-      fetchApi<{ id: string; name: string }[]>('/api/zones'),
-    ])
+    const p = await fetchApi<ListResponse<Parcel>>(
+      `/api/parcels?page=${page}&limit=${itemsPerPage}`
+    )
     if (p) {
       setItems(p.items)
       setTotalPages(p.totalPages)
       setCurrentPage(p.page)
     }
-    if (z) setZones(z)
   }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { load(currentPage) }, [currentPage])
+
+  useEffect(() => {
+    fetchApi<Parcel[]>("/api/parcels/all")
+      .then(setAllParcels)
+      .catch(() => setAllParcels([]))
+  }, [])
+
+  useEffect(() => {
+    fetchApi<{ id: string; name: string }[]>("/api/zones/all")
+      .then(setAllZones)
+      .catch(() => setAllZones([]))
+  }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -251,6 +263,23 @@ export default function ParcelsAdmin() {
         </CardContent>
       </Card>
 
+      <select
+        className="border p-2"
+        value={selectedParcelId}
+        onChange={e => setSelectedParcelId(e.target.value)}
+      >
+        {allParcels.length === 0 ? (
+          <option value="">Aucune parcelle trouvée</option>
+        ) : (
+          <>
+            <option value="">-- Sélectionnez une parcelle --</option>
+            {allParcels.map(a => (
+              <option key={a.id} value={a.id}>{a.reference}</option>
+            ))}
+          </>
+        )}
+      </select>
+
       <Pagination
         totalItems={totalPages * itemsPerPage}
         itemsPerPage={itemsPerPage}
@@ -309,9 +338,13 @@ export default function ParcelsAdmin() {
                   <SelectValue placeholder="Choisir" />
                 </SelectTrigger>
                 <SelectContent>
-                  {zones.map((z) => (
-                    <SelectItem key={z.id} value={z.id}>{z.name}</SelectItem>
-                  ))}
+                  {allZones.length === 0 ? (
+                    <SelectItem value="" disabled>Aucune zone trouvée</SelectItem>
+                  ) : (
+                    allZones.map((z) => (
+                      <SelectItem key={z.id} value={z.id}>{z.name}</SelectItem>
+                    ))
+                  )}
                 </SelectContent>
               </Select>
             </div>

--- a/Front-End/src/app/admin/regions/page.tsx
+++ b/Front-End/src/app/admin/regions/page.tsx
@@ -30,22 +30,24 @@ export default function RegionsAdmin() {
   const [currentPage, setCurrentPage] = useState(1)
   const itemsPerPage = 10
   const [open, setOpen] = useState(false)
-  const [countries, setCountries] = useState<{ id: string; name: string }[]>([])
+  const [allCountries, setAllCountries] = useState<{ id: string; name: string }[]>([])
   const [form, setForm] = useState<Region>({ id: '', name: '', code: '', countryId: '' })
 
 
   async function load() {
-    const [r, c] = await Promise.all([
-      fetchApi<Region[]>('/api/regions'),
-      fetchApi<{ id: string; name: string }[]>('/api/countries'),
-    ])
+    const r = await fetchApi<Region[]>('/api/regions')
     if (r) {
       setItems(r)
       setCurrentPage(1)
     }
-    if (c) setCountries(c)
   }
   useEffect(() => { load() }, [])
+
+  useEffect(() => {
+    fetchApi<{ id: string; name: string }[]>("/api/countries/all")
+      .then(setAllCountries)
+      .catch(() => setAllCountries([]))
+  }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -156,9 +158,13 @@ export default function RegionsAdmin() {
                   <SelectValue placeholder="Choisir" />
                 </SelectTrigger>
                 <SelectContent>
-                  {countries.map((c) => (
-                    <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
-                  ))}
+                  {allCountries.length === 0 ? (
+                    <SelectItem value="" disabled>Aucun pays trouvé</SelectItem>
+                  ) : (
+                    allCountries.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                    ))
+                  )}
                 </SelectContent>
               </Select>
             </div>

--- a/backend/src/main/java/com/industria/platform/controller/ActivityController.java
+++ b/backend/src/main/java/com/industria/platform/controller/ActivityController.java
@@ -28,6 +28,14 @@ public class ActivityController {
         return new ListResponse<>(items, res.getTotalElements(), res.getTotalPages(), p, l);
     }
 
+    @GetMapping("/all")
+    public List<ActivityDto> allActivities() {
+        return repo.findAll()
+                .stream()
+                .map(a -> new ActivityDto(a.getId(), a.getName(), a.getDescription(), a.getIcon(), a.getCategory()))
+                .toList();
+    }
+
     @GetMapping("/{id}")
     public ActivityDto get(@PathVariable String id) {
         Activity a = repo.findById(id).orElseThrow();

--- a/backend/src/main/java/com/industria/platform/controller/AmenityController.java
+++ b/backend/src/main/java/com/industria/platform/controller/AmenityController.java
@@ -28,6 +28,14 @@ public class AmenityController {
         return new ListResponse<>(items, res.getTotalElements(), res.getTotalPages(), p, l);
     }
 
+    @GetMapping("/all")
+    public List<AmenityDto> allAmenities() {
+        return repo.findAll()
+                .stream()
+                .map(a -> new AmenityDto(a.getId(), a.getName(), a.getDescription(), a.getIcon(), a.getCategory()))
+                .toList();
+    }
+
     @GetMapping("/{id}")
     public AmenityDto get(@PathVariable String id) {
         Amenity a = repo.findById(id).orElseThrow();

--- a/backend/src/main/java/com/industria/platform/controller/ParcelController.java
+++ b/backend/src/main/java/com/industria/platform/controller/ParcelController.java
@@ -44,6 +44,14 @@ public class ParcelController {
         return new ListResponse<>(items, res.getTotalElements(), res.getTotalPages(), p, l);
     }
 
+    @GetMapping("/all")
+    public List<ParcelDto> allParcels() {
+        return parcelRepository.findAll()
+                .stream()
+                .map(this::toDto)
+                .toList();
+    }
+
     @GetMapping("/{id}")
     public ParcelDto get(@PathVariable String id) {
         return parcelRepository.findById(id).map(this::toDto).orElse(null);

--- a/backend/src/main/java/com/industria/platform/controller/ZoneController.java
+++ b/backend/src/main/java/com/industria/platform/controller/ZoneController.java
@@ -60,6 +60,11 @@ public class ZoneController {
         return new ListResponse<>(items, res.getTotalElements(), res.getTotalPages(), p, l);
     }
 
+    @GetMapping("/all")
+    public List<ZoneDto> allZones() {
+        return zoneRepository.findAll().stream().map(this::toDto).toList();
+    }
+
     @GetMapping("/{id}")
     public ZoneDto get(@PathVariable String id) {
         Zone z = zoneRepository.findById(id).orElseThrow();


### PR DESCRIPTION
## Summary
- provide `/all` endpoints for activities, amenities, parcels and zones returning full lists
- load full data sets in admin pages alongside paginated results with example dropdowns
- define tables and seed data in `initDB.sql` to mirror JPA entities and include missing fields

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_688f6a2b3f78832c86ae5bfa9ae29c15