### PR TITLE
fix: seeding uses exported db password and guard admin lists

### DIFF
--- a/Front-End/src/app/admin/activities/page.tsx
+++ b/Front-End/src/app/admin/activities/page.tsx
@@ -36,7 +36,7 @@ export default function ActivitiesAdmin() {
 
 
   async function load(page = currentPage) {
-    const res = await fetchApi<ListResponse<Activity>>(`/api/activities?page=${page}&limit=${itemsPerPage}`)
+    const res = await fetchApi<ListResponse<Activity>>(`/api/activities?page=${page}&limit=${itemsPerPage}`).catch(() => null)
     if (res) {
       setItems(res.items)
       setTotalPages(res.totalPages)

--- a/Front-End/src/app/admin/amenities/page.tsx
+++ b/Front-End/src/app/admin/amenities/page.tsx
@@ -38,7 +38,7 @@ export default function AmenitiesAdmin() {
 
 
   async function load(page = currentPage) {
-    const res = await fetchApi<ListResponse<Amenity>>(`/api/amenities?page=${page}&limit=${itemsPerPage}`)
+    const res = await fetchApi<ListResponse<Amenity>>(`/api/amenities?page=${page}&limit=${itemsPerPage}`).catch(() => null)
     if (res) {
       setItems(res.items)
       setTotalPages(res.totalPages)

--- a/Front-End/src/app/admin/appointments/page.tsx
+++ b/Front-End/src/app/admin/appointments/page.tsx
@@ -29,6 +29,11 @@ interface Appointment {
   status: string
 }
 
+interface ParcelDto {
+  id: string
+  reference: string
+}
+
 const statuses = ['PENDING', 'CONFIRMED', 'COMPLETED', 'CANCELLED']
 
 export default function AppointmentsAdmin() {
@@ -37,7 +42,7 @@ export default function AppointmentsAdmin() {
   const [currentPage, setCurrentPage] = useState(1)
   const itemsPerPage = 10
   const [open, setOpen] = useState(false)
-  const [allParcels, setAllParcels] = useState<{ id: string; reference: string }[]>([])
+  const [parcels, setParcels] = useState<ParcelDto[]>([])
   const [form, setForm] = useState<Appointment>({
     id: '',
     contactName: '',
@@ -52,7 +57,7 @@ export default function AppointmentsAdmin() {
 
 
   async function load() {
-    const a = await fetchApi<Appointment[]>('/api/appointments')
+    const a = await fetchApi<Appointment[]>('/api/appointments').catch(() => null)
     if (a) {
       setItems(a)
       setCurrentPage(1)
@@ -61,9 +66,9 @@ export default function AppointmentsAdmin() {
   useEffect(() => { load() }, [])
 
   useEffect(() => {
-    fetchApi<{ id: string; reference: string }[]>("/api/parcels/all")
-      .then(setAllParcels)
-      .catch(() => setAllParcels([]))
+    fetchApi<{ items: ParcelDto[] }>("/api/parcels/all")
+      .then((data) => setParcels(data.items))
+      .catch(() => setParcels([]))
   }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -235,10 +240,10 @@ export default function AppointmentsAdmin() {
                   <SelectValue placeholder="Choisir" />
                 </SelectTrigger>
                 <SelectContent>
-                  {(allParcels ?? []).length === 0 ? (
+                  {(Array.isArray(parcels) ? parcels : []).length === 0 ? (
                     <SelectItem value="" disabled>Aucune parcelle trouvée</SelectItem>
                   ) : (
-                    (allParcels ?? []).map((p) => (
+                    (Array.isArray(parcels) ? parcels : []).map((p) => (
                       <SelectItem key={p.id} value={p.id}>{p.reference}</SelectItem>
                     ))
                   )}

--- a/Front-End/src/app/admin/countries/page.tsx
+++ b/Front-End/src/app/admin/countries/page.tsx
@@ -25,7 +25,7 @@ export default function CountriesAdmin() {
   const [form, setForm] = useState<Country>({ id: '', name: '', code: '' })
 
   async function load() {
-    const items = await fetchApi<Country[]>('/api/countries')
+    const items = await fetchApi<Country[]>('/api/countries').catch(() => null)
     if (items) {
       setItems(items)
       setCurrentPage(1)

--- a/Front-End/src/app/admin/page.tsx
+++ b/Front-End/src/app/admin/page.tsx
@@ -19,20 +19,22 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 
+const emptyStats = {
+  totalUsers: 0,
+  totalZones: 0,
+  availableParcels: 0,
+  totalParcels: 0,
+  pendingAppointments: 0,
+  totalAppointments: 0,
+  recentActivities: [] as unknown[],
+};
+
 async function getAdminStats() {
-  const data = await fetchApi('/api/admin/stats');
-  if (!data) {
-    return {
-      totalUsers: 0,
-      totalZones: 0,
-      availableParcels: 0,
-      totalParcels: 0,
-      pendingAppointments: 0,
-      totalAppointments: 0,
-      recentActivities: []
-    };
+  if (typeof window !== 'undefined') {
+    return emptyStats;
   }
-  return data;
+  const data = await fetchApi('/api/admin/stats').catch(() => null);
+  return data || emptyStats;
 }
 
 export default async function AdminDashboard() {
@@ -198,7 +200,7 @@ export default async function AdminDashboard() {
           {(filteredCards ?? []).map((card, index) => {
             const IconComponent = card.icon;
             return (
-              <Link key={index} href={card.href}>
+              <Link key={index} href={card.href} prefetch={false}>
                 <Card className="hover:shadow-lg transition-shadow cursor-pointer">
                   <CardHeader>
                     <div className="flex items-center gap-3">

--- a/Front-End/src/app/admin/parcels/page.tsx
+++ b/Front-End/src/app/admin/parcels/page.tsx
@@ -33,6 +33,11 @@ interface Parcel {
   zoneId: string
 }
 
+interface ZoneDto {
+  id: string
+  name: string
+}
+
 interface ParcelForm {
   id: string
   reference: string
@@ -54,7 +59,7 @@ export default function ParcelsAdmin() {
   const [totalPages, setTotalPages] = useState(1)
   const itemsPerPage = 10
   const [open, setOpen] = useState(false)
-  const [allZones, setAllZones] = useState<{ id: string; name: string }[]>([])
+  const [zones, setZones] = useState<ZoneDto[]>([])
   const [form, setForm] = useState<ParcelForm>({
     id: '',
     reference: '',
@@ -70,7 +75,7 @@ export default function ParcelsAdmin() {
   async function load(page = currentPage) {
     const p = await fetchApi<ListResponse<Parcel>>(
       `/api/parcels?page=${page}&limit=${itemsPerPage}`
-    )
+    ).catch(() => null)
     if (p) {
       setItems(p.items)
       setTotalPages(p.totalPages)
@@ -87,9 +92,9 @@ export default function ParcelsAdmin() {
   }, [])
 
   useEffect(() => {
-    fetchApi<{ id: string; name: string }[]>("/api/zones/all")
-      .then(setAllZones)
-      .catch(() => setAllZones([]))
+    fetchApi<{ items: ZoneDto[] }>("/api/zones/all")
+      .then((data) => setZones(data.items))
+      .catch(() => setZones([]))
   }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -338,11 +343,13 @@ export default function ParcelsAdmin() {
                   <SelectValue placeholder="Choisir" />
                 </SelectTrigger>
                 <SelectContent>
-                  {(allZones ?? []).length === 0 ? (
+                  {(Array.isArray(zones) ? zones : []).length === 0 ? (
                     <SelectItem value="" disabled>Aucune zone trouvée</SelectItem>
                   ) : (
-                    (allZones ?? []).map((z) => (
-                      <SelectItem key={z.id} value={z.id}>{z.name}</SelectItem>
+                    (Array.isArray(zones) ? zones : []).map((z) => (
+                      <SelectItem key={z.id} value={z.id}>
+                        {z.name}
+                      </SelectItem>
                     ))
                   )}
                 </SelectContent>

--- a/Front-End/src/app/admin/regions/page.tsx
+++ b/Front-End/src/app/admin/regions/page.tsx
@@ -35,7 +35,7 @@ export default function RegionsAdmin() {
 
 
   async function load() {
-    const r = await fetchApi<Region[]>('/api/regions')
+    const r = await fetchApi<Region[]>('/api/regions').catch(() => null)
     if (r) {
       setItems(r)
       setCurrentPage(1)

--- a/Front-End/src/app/admin/users/page.tsx
+++ b/Front-End/src/app/admin/users/page.tsx
@@ -49,7 +49,7 @@ export default function UsersAdmin() {
 
 
   const load = useCallback(async () => {
-    const users = await fetchApi<User[]>('/api/users')
+    const users = await fetchApi<User[]>('/api/users').catch(() => null)
     if (users) {
       setItems(users)
       setCurrentPage(1)

--- a/Front-End/src/app/admin/zone-types/page.tsx
+++ b/Front-End/src/app/admin/zone-types/page.tsx
@@ -24,7 +24,7 @@ export default function ZoneTypesAdmin() {
   const [form, setForm] = useState<ZoneType>({ id: '', name: '' })
 
   async function load() {
-    const items = await fetchApi<ZoneType[]>('/api/zone-types')
+    const items = await fetchApi<ZoneType[]>('/api/zone-types').catch(() => null)
     if (items) {
       setItems(items)
       setCurrentPage(1)

--- a/Front-End/src/app/admin/zones/page.tsx
+++ b/Front-End/src/app/admin/zones/page.tsx
@@ -39,6 +39,11 @@ interface Zone {
   vertices?: Vertex[]
 }
 
+interface ActivityDto {
+  id: string
+  name: string
+}
+
 interface ZoneForm {
   id: string
   name: string
@@ -71,7 +76,7 @@ export default function ZonesAdmin() {
   const [open, setOpen] = useState(false)
   const [allZoneTypes, setAllZoneTypes] = useState<{ id: string; name: string }[]>([])
   const [allRegions, setAllRegions] = useState<{ id: string; name: string }[]>([])
-  const [allActivities, setAllActivities] = useState<{ id: string; name: string }[]>([])
+  const [activities, setActivities] = useState<ActivityDto[]>([])
   const [allAmenities, setAllAmenities] = useState<{ id: string; name: string }[]>([])
   const [form, setForm] = useState<ZoneForm>({
     id: '',
@@ -93,7 +98,7 @@ export default function ZonesAdmin() {
   async function load(page = currentPage) {
     const z = await fetchApi<ListResponse<Zone>>(
       `/api/zones?page=${page}&limit=${itemsPerPage}`
-    )
+    ).catch(() => null)
     if (z) {
       setZones(z.items)
       setTotalPages(z.totalPages)
@@ -132,9 +137,9 @@ export default function ZonesAdmin() {
   }, [])
 
   useEffect(() => {
-    fetchApi<{ id: string; name: string }[]>("/api/activities/all")
-      .then(setAllActivities)
-      .catch(() => setAllActivities([]))
+    fetchApi<ListResponse<ActivityDto>>("/api/activities")
+      .then((data) => setActivities(data.items))
+      .catch(() => setActivities([]))
   }, [])
 
   useEffect(() => {
@@ -285,7 +290,7 @@ export default function ZonesAdmin() {
       status: z.status,
       zoneTypeId: z.zoneTypeId || '',
       regionId: z.regionId || '',
-      activityIds: z.activities ? z.activities.map(a => a.activityId) : [],
+      activityIds: Array.isArray(z.activities) ? z.activities.map(a => a.activityId) : [],
       amenityIds: z.amenities ? z.amenities.map(a => a.amenityId) : [],
       vertices: z.vertices ? z.vertices.sort((a,b)=>a.seq-b.seq).map(v => ({
         lambertX: v.lambertX.toString(),
@@ -481,7 +486,7 @@ export default function ZonesAdmin() {
             <div>
               <Label>Activités</Label>
               <div className="flex flex-wrap gap-2">
-                {(allActivities ?? []).map((a) => (
+                {(Array.isArray(activities) ? activities : []).map((a) => (
                   <label key={a.id} className="flex items-center space-x-1">
                     <input
                       type="checkbox"

--- a/backend/db/init/initDB.sql
+++ b/backend/db/init/initDB.sql
@@ -178,12 +178,12 @@ INSERT INTO notification_template (
     id, type, subject, html_body, text_body, created_at, updated_at
 )
 SELECT * FROM (VALUES
-    ('tmpl-appointment-confirm', 'EMAIL',
+    ('tmpl-appointment-confirm', 'email',
      'Confirmation RDV',
      'Votre rendez-vous pour la parcelle {parcel_reference} est confirmé pour le {date}.',
      'Votre rendez-vous pour la parcelle {parcel_reference} est confirmé pour le {date}.',
      NOW(), NOW()),
-    ('tmpl-parcel-available', 'EMAIL',
+    ('tmpl-parcel-available', 'email',
      'Parcelle disponible',
      'Une nouvelle parcelle correspondant à vos critères est disponible : {parcel_reference}.',
      'Une nouvelle parcelle correspondant à vos critères est disponible : {parcel_reference}.',

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -7,7 +7,8 @@ DB_NAME=${DB_NAME:-industria}
 DB_USER=${DB_USER:-postgres}
 DB_PASSWORD=${DB_PASSWORD:-postgres}
 
-PSQL="docker compose exec -e PGPASSWORD=$DB_PASSWORD -T $DB_CONTAINER psql -U $DB_USER -d $DB_NAME"
+export PGPASSWORD="$DB_PASSWORD"
+PSQL="docker compose exec -e PGPASSWORD -T $DB_CONTAINER psql -U $DB_USER -d $DB_NAME"
 
 if $PSQL -tAc "SELECT 1 FROM information_schema.tables WHERE table_name='users'" | grep -q 1; then
     if $PSQL -tAc "SELECT 1 FROM users LIMIT 1" | grep -q 1; then

--- a/scripts/wait-for-tables.sh
+++ b/scripts/wait-for-tables.sh
@@ -6,6 +6,7 @@ DB_HOST=${DB_HOST:-db}
 DB_NAME=${DB_NAME:-industria}
 DB_USER=${DB_USER:-postgres}
 DB_PASSWORD=${DB_PASSWORD:-postgres}
+export PGPASSWORD="$DB_PASSWORD"
 
 echo "🔍 Waiting for Hibernate to create tables..."
 
@@ -24,7 +25,7 @@ REQUIRED_TABLES=(
 
 check_table_exists() {
     local table_name=$1
-    PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d $DB_NAME -tAc \
+    psql -h $DB_HOST -U $DB_USER -d $DB_NAME -tAc \
         "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='$table_name'" 2>/dev/null || echo ""
 }
 
@@ -60,7 +61,7 @@ wait_for_all_tables() {
 
 # Attendre d'abord que PostgreSQL soit accessible
 echo "🔌 Checking PostgreSQL connection..."
-while ! PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d $DB_NAME -c '\q' 2>/dev/null; do
+while ! psql -h $DB_HOST -U $DB_USER -d $DB_NAME -c '\q' 2>/dev/null; do
     echo "   Waiting for PostgreSQL connection..."
     sleep 2
 done


### PR DESCRIPTION
## Summary
- export `PGPASSWORD` before invoking `psql` in database init scripts
- use lowercase enum value when seeding notification templates
- guard activities on admin zones page with empty-array defaults and API response handling
- handle parcels list on admin appointments page with array defaults and safe mapping
- ensure zones list on admin parcels page uses array defaults and guarded mapping

## Testing
- `cd Front-End && npm test` *(fails: Missing script: "test")*
- `cd Front-End && npm run lint` *(fails: Unexpected any in unrelated files)*
- `(cd backend && ./mvnw -q test)` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893262d9588832cb20eeb1820fb614a