### PR TITLE
feat(map): load simplified zone geometry by zoom

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -46,10 +46,16 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-oauth2-client</artifactId>
                 </dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.locationtech.jts</groupId>
+                        <artifactId>jts-core</artifactId>
+                        <version>1.19.0</version>
+                </dependency>
 
                 <dependency>
                         <groupId>org.postgresql</groupId>

--- a/backend/src/main/java/com/industria/platform/controller/MapController.java
+++ b/backend/src/main/java/com/industria/platform/controller/MapController.java
@@ -2,26 +2,42 @@ package com.industria.platform.controller;
 
 import com.industria.platform.dto.ParcelFeatureDto;
 import com.industria.platform.dto.ZoneFeatureDto;
+import com.industria.platform.dto.ZoneSimplifiedFeatureDto;
 import com.industria.platform.entity.Parcel;
 import com.industria.platform.entity.ParcelStatus;
 import com.industria.platform.entity.Zone;
 import com.industria.platform.repository.ParcelRepository;
 import com.industria.platform.repository.ZoneRepository;
+import com.industria.platform.service.CoordinateCalculationService;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RestController
 @RequestMapping("/api/map")
 public class MapController {
     private final ZoneRepository zoneRepository;
     private final ParcelRepository parcelRepository;
+    private final CoordinateCalculationService coordinateService;
+    private final Map<Integer, List<ZoneSimplifiedFeatureDto>> simplifiedCache = new ConcurrentHashMap<>();
 
-    public MapController(ZoneRepository zoneRepository, ParcelRepository parcelRepository) {
+    public MapController(ZoneRepository zoneRepository,
+                         ParcelRepository parcelRepository,
+                         CoordinateCalculationService coordinateService) {
         this.zoneRepository = zoneRepository;
         this.parcelRepository = parcelRepository;
+        this.coordinateService = coordinateService;
     }
 
     @GetMapping("/zones")
@@ -43,6 +59,47 @@ public class MapController {
                         Boolean.TRUE.equals(p.getIsShowroom()), p.getStatus().name())
         ).toList();
         return new MapResponse<>(features);
+    }
+
+    @GetMapping("/zones/simplified")
+    public MapResponse<ZoneSimplifiedFeatureDto> simplifiedZones(@RequestParam(defaultValue = "6") int zoom) {
+        List<ZoneSimplifiedFeatureDto> features = simplifiedCache.computeIfAbsent(zoom, this::buildSimplifiedZones);
+        return new MapResponse<>(features);
+    }
+
+    private List<ZoneSimplifiedFeatureDto> buildSimplifiedZones(int zoom) {
+        double tolerance = zoomToTolerance(zoom);
+        WKTReader reader = new WKTReader();
+        return zoneRepository.findAll().stream().map(z -> {
+            try {
+                Geometry geom = reader.read(z.getGeometry());
+                Geometry simplified = DouglasPeuckerSimplifier.simplify(geom, tolerance);
+                List<double[]> coords = new ArrayList<>();
+                for (Coordinate c : simplified.getCoordinates()) {
+                    double[] wgs = coordinateService.lambertToWGS84(c.getX(), c.getY());
+                    coords.add(new double[]{wgs[1], wgs[0]}); // lat, lon
+                }
+                return new ZoneSimplifiedFeatureDto(
+                        coords,
+                        z.getId(),
+                        z.getName(),
+                        z.getStatus().name(),
+                        parcelRepository.countByZoneIdAndStatus(z.getId(), ParcelStatus.LIBRE),
+                        z.getActivities() == null ? List.of() : z.getActivities().stream().map(a -> a.getActivity().getIcon()).toList(),
+                        z.getAmenities() == null ? List.of() : z.getAmenities().stream().map(a -> a.getAmenity().getIcon()).toList()
+                );
+            } catch (Exception e) {
+                return null;
+            }
+        }).filter(Objects::nonNull).toList();
+    }
+
+    private double zoomToTolerance(int zoom) {
+        if (zoom >= 15) return 5;
+        if (zoom >= 12) return 20;
+        if (zoom >= 10) return 50;
+        if (zoom >= 8) return 100;
+        return 200;
     }
 
     private double[] parseCentroid(String wkt) {

--- a/backend/src/main/java/com/industria/platform/dto/ZoneSimplifiedFeatureDto.java
+++ b/backend/src/main/java/com/industria/platform/dto/ZoneSimplifiedFeatureDto.java
@@ -1,0 +1,16 @@
+package com.industria.platform.dto;
+
+import java.util.List;
+
+/**
+ * DTO pour exposer des zones avec géométrie simplifiée.
+ */
+public record ZoneSimplifiedFeatureDto(
+        List<double[]> coordinates,
+        String id,
+        String name,
+        String status,
+        int availableParcels,
+        List<String> activityIcons,
+        List<String> amenityIcons
+) {}


### PR DESCRIPTION
## Summary
- add JTS and new `/api/map/zones/simplified` endpoint returning simplified polygons with LOD cache
- fetch simplified zone polygons per zoom level in HomeMapView and redraw only when needed

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network unreachable)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6894b6dba7fc832ca4b7ade4174d0cca